### PR TITLE
Fix short URL generation host parsing

### DIFF
--- a/app/services/simple_link_service.rb
+++ b/app/services/simple_link_service.rb
@@ -1,13 +1,14 @@
+require 'uri'
+
 class SimpleLinkService
   def initialize(simple_link)
     @simple_link = simple_link
   end
 
   def get_link
-    regex = /(https:\/\/www\.|http:\/\/www\.|https:\/\/|http:\/\/)?[a-zA-Z0-9]{2,}(\.[a-zA-Z0-9]{2,})(\.[a-zA-Z0-9]{2,})?/
-    url_host = @simple_link.url.match(regex)[0]
-
-    url_host + '/' + @simple_link.short_url
+    uri = URI.parse(@simple_link.url)
+    host = [uri.scheme, uri.host].join('://')
+    File.join(host, @simple_link.short_url)
   end
 
   def increment_link_counter


### PR DESCRIPTION
## Summary
- ensure short link generation parses hosts using `URI`

## Testing
- `bundle exec rspec` *(fails: ActiveRecord::DatabaseConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_684054d63c9c833098bbafb2212bb405