### PR TITLE
Migrate project from GitLab to GitHub

### DIFF
--- a/.gitlab-ci-background-jobs.yml
+++ b/.gitlab-ci-background-jobs.yml
@@ -1,0 +1,32 @@
+# Пример использования GitLab CI для background jobs
+
+stages:
+  - scheduled_jobs
+
+# Ежедневная задача
+daily_cleanup:
+  stage: scheduled_jobs
+  script:
+    - bundle exec rails cleanup:old_records
+  only:
+    - schedules
+  rules:
+    - if: '$SCHEDULE_TYPE == "daily"'
+
+# Еженедельная задача
+weekly_report:
+  stage: scheduled_jobs
+  script:
+    - bundle exec rails reports:generate_weekly
+  only:
+    - schedules
+  rules:
+    - if: '$SCHEDULE_TYPE == "weekly"'
+
+# Задача по webhook
+process_webhook:
+  stage: scheduled_jobs
+  script:
+    - bundle exec rails webhooks:process
+  only:
+    - triggers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+stages:
+  - mirror
+
+mirror_to_github:
+  stage: mirror
+  script:
+    - git remote add github https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${GITHUB_USERNAME}/${GITHUB_REPO_NAME}.git || true
+    - git push --mirror github
+  only:
+    - main
+    - master
+  variables:
+    GIT_STRATEGY: clone
+    GIT_DEPTH: 0

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,10 @@ gem "puma", ">= 5.0"
 # gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
+
+# Background jobs
+gem "sidekiq", "~> 7.2"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,8 @@
+# Конфигурация Sidekiq
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") }
+end

--- a/migrate_to_github.sh
+++ b/migrate_to_github.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Скрипт для миграции репозитория с GitLab на GitHub
+
+echo "Этот скрипт поможет вам перенести репозиторий с GitLab на GitHub"
+echo "Убедитесь, что у вас создан пустой репозиторий на GitHub"
+
+# Добавление GitHub как удаленного репозитория
+echo "Добавление GitHub remote..."
+git remote add github https://github.com/YOUR_GITHUB_USERNAME/YOUR_REPO_NAME.git
+
+# Показать текущие remote
+echo "Текущие remote репозитории:"
+git remote -v
+
+# Push всех веток
+echo "Отправка всех веток на GitHub..."
+git push github --all
+
+# Push всех тегов
+echo "Отправка всех тегов на GitHub..."
+git push github --tags
+
+echo "Миграция завершена!"
+echo "Теперь вы можете:"
+echo "1. Изменить origin на GitHub: git remote set-url origin https://github.com/YOUR_GITHUB_USERNAME/YOUR_REPO_NAME.git"
+echo "2. Удалить GitLab remote: git remote remove origin"
+echo "3. Переименовать github в origin: git remote rename github origin"


### PR DESCRIPTION
Implement solutions for background job execution, offering GitLab to GitHub mirroring, a migration script, and Sidekiq integration for projects hosted on GitLab.

This PR addresses the user's need to run background jobs when their project is hosted on GitLab, especially if GitHub-specific features (like GitHub Actions) are desired, or if a robust, Rails-native background job system like Sidekiq is preferred. It provides flexible options to either integrate with GitHub or enhance GitLab-native capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a11a5fa-9d4f-427e-abae-c7a88e653ba6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a11a5fa-9d4f-427e-abae-c7a88e653ba6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

